### PR TITLE
fix(ci): Set fetch-depth to 0 for full git history

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -103,6 +103,8 @@ jobs:
       # 步骤 1: 检出你的仓库代码
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 
 
       # 步骤 2: 设置 Python 环境
       - name: Set up Python


### PR DESCRIPTION
This pull request makes a minor update to the GitHub Actions workflow for documentation deployment. The change ensures that the repository is checked out with full history, which can be important for workflows that rely on commit history.

* Set `fetch-depth: 0` in the `actions/checkout` step of `.github/workflows/deploy-docs.yml` to fetch the entire repository history.